### PR TITLE
Allow user-defined COLABFOLD_DIR in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,8 +5,12 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 BIOEMU_ENV_NAME="bioemu"
 UPDATE_ENV="${UPDATE_ENV:-0}"
 
-# Set up colabfold
-export COLABFOLD_DIR=$HOME/.localcolabfold # Where colabfold will be installed
+# Set COLABFOLD_DIR to ~/.localcolabfold if env var not set
+if [[ -z "${COLABFOLD_DIR}" ]]; then
+  COLABFOLD_DIR=~/.localcolabfold
+else
+  COLABFOLD_DIR="${COLABFOLD_DIR}"
+fi
 if [ -f $COLABFOLD_DIR/localcolabfold/colabfold-conda/bin/colabfold_batch ]; then
   echo "colabfold already installed in $COLABFOLD_DIR/localcolabfold/colabfold-conda/bin/colabfold_batch"
 else


### PR DESCRIPTION
Currently, the colabfold setup script respects the user defined COLABFOLD_DIR  environment variable, but setup.sh hardcodes this path to $HOME/.localcolabfold.
https://github.com/microsoft/bioemu/blob/3dcebbd0f2456491900c48182ea5353fc0bae086/setup.sh#L9

This PR modifies setup.sh to allow the user to choose where colabfold is installed by setting an environment variable.

