### PR TITLE
Support using own MSA server to compute embeddings

### DIFF
--- a/src/bioemu/sample.py
+++ b/src/bioemu/sample.py
@@ -68,6 +68,7 @@ def main(
     model_config_path: str | Path | None = None,
     denoiser_config_path: str | Path = DEFAULT_DENOISER_CONFIG_PATH,
     cache_embeds_dir: str | Path | None = None,
+    msa_host_url: str | None = None,
 ) -> None:
     """
     Generate samples for a specified sequence, using a trained model.
@@ -85,6 +86,7 @@ def main(
            Only required if `ckpt_path` is set.
         denoiser_config_path: Path to the denoiser config, defining the denoising process.
         cache_embeds_dir: Directory to store MSA embeddings. If not set, this defaults to `COLABFOLD_DIR/embeds_cache`.
+        msa_host_url: MSA server URL. If not set, this defaults to collabfold's remote server.
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)  # Fail fast if output_dir is non-writeable
@@ -149,6 +151,7 @@ def main(
             seed=seed,
             denoiser=denoiser,
             cache_embeds_dir=cache_embeds_dir,
+            msa_host_url=msa_host_url,
         )
         batch = {k: v.cpu().numpy() for k, v in batch.items()}
         np.savez(npz_path, **batch, sequence=sequence)
@@ -180,6 +183,7 @@ def generate_batch(
     seed: int,
     denoiser: Callable,
     cache_embeds_dir: str | Path | None,
+    msa_host_url: str | None = None,
 ) -> dict[str, torch.Tensor]:
     """Generate one batch of samples, using GPU if available.
 
@@ -190,13 +194,14 @@ def generate_batch(
         embeddings_file: Path to embeddings file.
         batch_size: Batch size.
         seed: Random seed.
+        msa_host_url: MSA server URL for colabfold.
     """
 
     torch.manual_seed(seed)
     n = len(sequence)
 
     single_embeds_file, pair_embeds_file = get_colabfold_embeds(
-        seq=sequence, cache_embeds_dir=cache_embeds_dir
+        seq=sequence, cache_embeds_dir=cache_embeds_dir, msa_host_url=msa_host_url
     )
     single_embeds = np.load(single_embeds_file)
     pair_embeds = np.load(pair_embeds_file)

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -10,7 +10,9 @@ from bioemu.get_embeds import StrPath, get_colabfold_embeds, shahexencode
 TEST_SEQ = "TESTSEQ"
 
 
-def mock_run_colabfold(fasta_file: StrPath, res_dir: StrPath, colabfold_env: dict[str, str]) -> int:
+def mock_run_colabfold(
+    fasta_file: StrPath, res_dir: StrPath, colabfold_env: dict[str, str], msa_host_url: str | None
+) -> int:
     seq = TEST_SEQ
     seqsha = os.path.basename(fasta_file).split(".")[0]
     single_rep_tempfile = os.path.join(


### PR DESCRIPTION
Allows users to specify msa server other than colabfold's default one when generating embeddings. 

Note: used `msa_host_url` parameter name instead of `host_url` to avoid Fire CLI's automatic shortening to `-h` which would conflict with help flag.

Closes #28