### PR TITLE
chore: add platform specific tag in `publish.yml`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade build twine
+          python -m pip install --upgrade build twine wheel
 
       - name: Build
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: |
           python -m build
-          python -m wheel tags --platform-tag manylinux dist/*any.whl
+          python -m wheel tags --platform-tag manylinux1_x86_64 dist/*any.whl
           rm dist/*any.whl
 
       - name: Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Build
         run: |
           python -m build
+          python -m wheel tags --platform-tag linux-x86_64 dist/*any.whl
+          rm dist/*any.whl
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: |
           python -m build
-          python -m wheel tags --platform-tag linux-x86_64 dist/*any.whl
+          python -m wheel tags --platform-tag linux_x86_64 dist/*any.whl
           rm dist/*any.whl
 
       - name: Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: |
           python -m build
-          python -m wheel tags --platform-tag linux_x86_64 dist/*any.whl
+          python -m wheel tags --platform-tag manylinux dist/*any.whl
           rm dist/*any.whl
 
       - name: Publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bioemu"
-version = "0.1.2"
+version = "0.1.3"
 description = "Biomolecular emulator"
 authors = [
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "stackprinter",
     "typer"
 ]
+readme = "README.md"
+
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
 ]
 readme = "README.md"
 
-
 [project.optional-dependencies]
 dev = [
     "pytest", # For developers


### PR DESCRIPTION
So that users can't accidentally retrieve the package from MacOS / Windows. Follows platform tags from [here](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/).

Also adds `README.md` to the `[project]` section of the pyproject file so that it's picked up by pypi.

Fixes #50