### PR TITLE
chore: Allow users to choose denoiser

### DIFF
--- a/src/bioemu/sample.py
+++ b/src/bioemu/sample.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+import typing
 from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
@@ -30,7 +31,8 @@ from .utils import count_samples_in_output_dir, format_npz_samples_filename
 logger = logging.getLogger(__name__)
 
 DEFAULT_DENOISER_CONFIG_DIR = Path(__file__).parent / "config/denoiser/"
-SUPPORTED_DENOISERS = ["heun", "dpm"]
+SupportedDenoisersLiteral = Literal["dpm", "heun"]
+SUPPORTED_DENOISERS = list(typing.get_args(SupportedDenoisersLiteral))
 
 
 def maybe_download_checkpoint(
@@ -68,7 +70,7 @@ def main(
     model_name: str | None = "bioemu-v1.0",
     ckpt_path: str | Path | None = None,
     model_config_path: str | Path | None = None,
-    denoiser_type: Literal["dpm", "heun"] | None = "dpm",
+    denoiser_type: SupportedDenoisersLiteral | None = "dpm",
     denoiser_config_path: str | Path | None = None,
     cache_embeds_dir: str | Path | None = None,
     msa_host_url: str | None = None,

--- a/src/bioemu/sample.py
+++ b/src/bioemu/sample.py
@@ -5,8 +5,8 @@
 import logging
 import os
 from collections.abc import Callable
-from enum import Enum
 from pathlib import Path
+from typing import Literal
 
 import hydra
 import numpy as np
@@ -30,11 +30,7 @@ from .utils import count_samples_in_output_dir, format_npz_samples_filename
 logger = logging.getLogger(__name__)
 
 DEFAULT_DENOISER_CONFIG_DIR = Path(__file__).parent / "config/denoiser/"
-
-
-class DenoiserType(str, Enum):
-    HEUN = "heun"
-    DPM = "dpm"
+SUPPORTED_DENOISERS = ["heun", "dpm"]
 
 
 def maybe_download_checkpoint(
@@ -72,7 +68,7 @@ def main(
     model_name: str | None = "bioemu-v1.0",
     ckpt_path: str | Path | None = None,
     model_config_path: str | Path | None = None,
-    denoiser_type: DenoiserType | None = DenoiserType.DPM,
+    denoiser_type: Literal["dpm", "heun"] | None = "dpm",
     denoiser_config_path: str | Path | None = None,
     cache_embeds_dir: str | Path | None = None,
 ) -> None:
@@ -127,7 +123,8 @@ def main(
 
     if denoiser_config_path is None:
         assert denoiser_type is not None
-        denoiser_config_path = DEFAULT_DENOISER_CONFIG_DIR / f"{denoiser_type.value}.yaml"
+        assert denoiser_type in SUPPORTED_DENOISERS
+        denoiser_config_path = DEFAULT_DENOISER_CONFIG_DIR / f"{denoiser_type}.yaml"
 
     with open(denoiser_config_path) as f:
         denoiser_config = yaml.safe_load(f)

--- a/src/bioemu/sample.py
+++ b/src/bioemu/sample.py
@@ -37,12 +37,6 @@ class DenoiserType(str, Enum):
     DPM = "dpm"
 
 
-DEFAULT_DENOISER_CONFIG_PATHS: dict[DenoiserType, Path] = {
-    DenoiserType.HEUN: DEFAULT_DENOISER_CONFIG_DIR / "heun.yaml",
-    DenoiserType.DPM: DEFAULT_DENOISER_CONFIG_DIR / "dpm.yaml",
-}
-
-
 def maybe_download_checkpoint(
     *,
     model_name: str | None,
@@ -133,7 +127,7 @@ def main(
 
     if denoiser_config_path is None:
         assert denoiser_type is not None
-        denoiser_config_path = DEFAULT_DENOISER_CONFIG_PATHS[denoiser_type]
+        denoiser_config_path = DEFAULT_DENOISER_CONFIG_DIR / f"{denoiser_type.value}.yaml"
 
     with open(denoiser_config_path) as f:
         denoiser_config = yaml.safe_load(f)

--- a/src/bioemu/sample.py
+++ b/src/bioemu/sample.py
@@ -86,7 +86,7 @@ def main(
         ckpt_path: Path to the model checkpoint. If this is set, `model_name` will be ignored.
         model_config_path: Path to the model config, defining score model architecture and the corruption process the model was trained with.
            Only required if `ckpt_path` is set.
-        denoiser_type: Denoiser to use for sampling, if `denoiser_config_path` not specified. Comes in with default parameter configuration
+        denoiser_type: Denoiser to use for sampling, if `denoiser_config_path` not specified. Comes in with default parameter configuration. Must be one of ['dpm', 'heun']
         denoiser_config_path: Path to the denoiser config, defining the denoising process.
         cache_embeds_dir: Directory to store MSA embeddings. If not set, this defaults to `COLABFOLD_DIR/embeds_cache`.
     """
@@ -122,7 +122,9 @@ def main(
     sdes: dict[str, SDE] = hydra.utils.instantiate(model_config["sdes"])
 
     if denoiser_config_path is None:
-        assert denoiser_type in SUPPORTED_DENOISERS
+        assert (
+            denoiser_type in SUPPORTED_DENOISERS
+        ), f"denoiser_type must be one of {SUPPORTED_DENOISERS}"
         denoiser_config_path = DEFAULT_DENOISER_CONFIG_DIR / f"{denoiser_type}.yaml"
 
     with open(denoiser_config_path) as f:

--- a/src/bioemu/sample.py
+++ b/src/bioemu/sample.py
@@ -122,7 +122,6 @@ def main(
     sdes: dict[str, SDE] = hydra.utils.instantiate(model_config["sdes"])
 
     if denoiser_config_path is None:
-        assert denoiser_type is not None
         assert denoiser_type in SUPPORTED_DENOISERS
         denoiser_config_path = DEFAULT_DENOISER_CONFIG_DIR / f"{denoiser_type}.yaml"
 


### PR DESCRIPTION
Allows users to choose between the Heun and DPM solvers using the default config files available in the package.