### PR TITLE
chore: check that colabfold is patched

### DIFF
--- a/src/bioemu/colabfold_setup/setup.sh
+++ b/src/bioemu/colabfold_setup/setup.sh
@@ -22,4 +22,5 @@ echo "Patching colabfold installation..."
 patch ${COLABFOLD_DIR}/localcolabfold/colabfold-conda/lib/python3.10/site-packages/alphafold/model/modules.py ${SCRIPT_DIR}/modules.patch
 patch ${COLABFOLD_DIR}/localcolabfold/colabfold-conda/lib/python3.10/site-packages/colabfold/batch.py ${SCRIPT_DIR}/batch.patch
 
+touch ${COLABFOLD_DIR}/.COLABFOLD_PATCHED
 echo "Colabfold installation complete!"

--- a/src/bioemu/get_embeds.py
+++ b/src/bioemu/get_embeds.py
@@ -59,10 +59,14 @@ def ensure_colabfold_install(colabfold_dir: StrPath) -> str:
     colabfold_batch_exec = os.path.join(
         colabfold_dir, "localcolabfold", "colabfold-conda", "bin", "colabfold_batch"
     )
+    colabfold_patched_file = os.path.join(colabfold_dir, ".COLABFOLD_PATCHED")
     colabfold_bin_dir = os.path.dirname(colabfold_batch_exec)
     if os.path.exists(colabfold_batch_exec):
         # Colabfold present
-        pass
+        # Check whether it's been patched
+        assert os.path.exists(
+            colabfold_patched_file
+        ), "Colabfold has not been patched. Do not set $COLABFOLD_DIR to a pre-existing installation"
     else:
         logger.info(f"Colabfold not present under {colabfold_dir}. Installing...")
         os.makedirs(colabfold_dir, exist_ok=True)


### PR DESCRIPTION
Checks whether the colabfold installation under `$COLABFOLD_DIR` has been correctly patched. This avoids users from setting that environment variable to a pre-existing colabfold installation - which would result on them complaining about missing embedding files.

Fixes #52 