### PR TITLE
chore: refactor `HPACKER_PYTHONBIN`

### DIFF
--- a/src/bioemu/sidechain_relax.py
+++ b/src/bioemu/sidechain_relax.py
@@ -26,14 +26,6 @@ logger = logging.getLogger(__name__)
 
 HPACKER_ENVNAME = os.getenv("HPACKER_ENV_NAME", HPACKER_DEFAULT_ENVNAME)
 HPACKER_REPO_DIR = os.getenv("HPACKER_REPO_DIR", HPACKER_DEFAULT_REPO_DIR)
-_DEFAULT_HPACKER_PYTHONBIN = os.path.join(
-    get_conda_prefix(),
-    "envs",
-    HPACKER_ENVNAME,
-    "bin",
-    "python",
-)
-HPACKER_PYTHONBIN = os.getenv("HPACKER_PYTHONBIN", _DEFAULT_HPACKER_PYTHONBIN)
 
 
 class MDProtocol(str, Enum):
@@ -46,9 +38,18 @@ def _run_hpacker(protein_pdb_in: str, protein_pdb_out: str) -> None:
     # make sure that hpacker env is set up
     ensure_hpacker_install(envname=HPACKER_ENVNAME, repo_dir=HPACKER_REPO_DIR)
 
+    _default_hpacker_pythonbin = os.path.join(
+        get_conda_prefix(),
+        "envs",
+        HPACKER_ENVNAME,
+        "bin",
+        "python",
+    )
+    hpacker_pythonbin = os.getenv("HPACKER_PYTHONBIN", _default_hpacker_pythonbin)
+
     result = subprocess.run(
         [
-            HPACKER_PYTHONBIN,
+            hpacker_pythonbin,
             os.path.abspath(os.path.join(os.path.dirname(__file__), "run_hpacker.py")),
             protein_pdb_in,
             protein_pdb_out,

--- a/src/bioemu/sidechain_relax.py
+++ b/src/bioemu/sidechain_relax.py
@@ -20,17 +20,20 @@ from bioemu.hpacker_setup.setup_hpacker import (
     ensure_hpacker_install,
 )
 from bioemu.md_utils import get_propka_protonation
+from bioemu.utils import get_conda_prefix
 
 logger = logging.getLogger(__name__)
 
 HPACKER_ENVNAME = os.getenv("HPACKER_ENV_NAME", HPACKER_DEFAULT_ENVNAME)
 HPACKER_REPO_DIR = os.getenv("HPACKER_REPO_DIR", HPACKER_DEFAULT_REPO_DIR)
-HPACKER_PYTHONBIN = os.path.join(
-    os.path.abspath(os.path.join(os.environ["CONDA_PREFIX"], "..")),
+_DEFAULT_HPACKER_PYTHONBIN = os.path.join(
+    get_conda_prefix(),
+    "envs",
     HPACKER_ENVNAME,
     "bin",
     "python",
 )
+HPACKER_PYTHONBIN = os.getenv("HPACKER_PYTHONBIN", _DEFAULT_HPACKER_PYTHONBIN)
 
 
 class MDProtocol(str, Enum):

--- a/src/bioemu/utils.py
+++ b/src/bioemu/utils.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-
+import os
 from pathlib import Path
 
 
@@ -20,3 +20,22 @@ def count_samples_in_output_dir(output_dir: Path) -> int:
         for pair in [p.stem.split("_")[1:]]
     ]
     return sum(num_samples)
+
+
+_conda_not_installed_errmsg = "conda not installed"
+
+
+def get_conda_prefix() -> str:
+    """
+    Attempts to find the root Conda folder. Works with miniforge3/miniconda3
+    """
+    conda_root = os.getenv("CONDA_ROOT", None)
+    if conda_root is None:
+        # Attempt $CONDA_PREFIX_1 or $CONDA_PREFIX, depending
+        # on whether the `base` environment is activated.
+        default_env_name = os.getenv("CONDA_DEFAULT_ENV", None)
+        assert default_env_name is not None, _conda_not_installed_errmsg
+        conda_prefix_env_name = "CONDA_PREFIX" if default_env_name == "base" else "CONDA_PREFIX_1"
+        conda_root = os.getenv(conda_prefix_env_name, None)
+    assert conda_root is not None, _conda_not_installed_errmsg
+    return conda_root


### PR DESCRIPTION
* Refactors the `HPACKER_PYTHONBIN` variable in the hpacker module to optionally use the `$HPACKER_PYTHONBIN` environment variable if set. This is mostly done to avoid monkey patching the variable in the Colab notebook.
* Moves `get_conda_prefix` function to `utils` since it now gets used both by the colabfold and hpacker dependencies.