### PR TITLE
fix: MD relaxation with multiple samples

### DIFF
--- a/src/bioemu/sidechain_relax.py
+++ b/src/bioemu/sidechain_relax.py
@@ -192,7 +192,7 @@ def run_all_md(samples_all: list[mdtraj.Trajectory], md_protocol: MDProtocol) ->
             "Could not create MD setups for given system. Try running MD setup on reconstructed samples manually."
         )
 
-    equil_traj = mdtraj.Trajectory(np.concatenate(equil_xyz), samples_all[-1].top.subset(atom_idx))
+    equil_traj = mdtraj.Trajectory(np.concatenate([xyz[np.newaxis, ...] for xyz in equil_xyz], axis=0), samples_all[-1].top.subset(atom_idx))
     return equil_traj
 
 

--- a/src/bioemu/sidechain_relax.py
+++ b/src/bioemu/sidechain_relax.py
@@ -192,7 +192,10 @@ def run_all_md(samples_all: list[mdtraj.Trajectory], md_protocol: MDProtocol) ->
             "Could not create MD setups for given system. Try running MD setup on reconstructed samples manually."
         )
 
-    equil_traj = mdtraj.Trajectory(np.concatenate([xyz[np.newaxis, ...] for xyz in equil_xyz], axis=0), samples_all[-1].top.subset(atom_idx))
+    equil_traj = mdtraj.Trajectory(
+        np.concatenate([xyz[np.newaxis, ...] for xyz in equil_xyz], axis=0),
+        samples_all[-1].top.subset(atom_idx),
+    )
     return equil_traj
 
 


### PR DESCRIPTION
The MD relaxation step was failing when sampling from bioemu with multiple samples due to an indexing mismatch.

![image](https://github.com/user-attachments/assets/2cd8871a-c2d5-4897-9f92-7b4be98cf25b)
