### PR TITLE
fix: reconstructed sidechains saved in current dir

### DIFF
--- a/src/bioemu/sidechain_relax.py
+++ b/src/bioemu/sidechain_relax.py
@@ -192,7 +192,7 @@ def run_all_md(samples_all: list[mdtraj.Trajectory], md_protocol: MDProtocol) ->
             "Could not create MD setups for given system. Try running MD setup on reconstructed samples manually."
         )
 
-    equil_traj = mdtraj.Trajectory(np.concatenate(equil_xyz), samples_all[-1].top.subset(atom_idx))
+    equil_traj = mdtraj.Trajectory(np.concatenate([xyz[np.newaxis, ...] for xyz in equil_xyz], axis=0), samples_all[-1].top.subset(atom_idx))
     return equil_traj
 
 

--- a/src/bioemu/sidechain_relax.py
+++ b/src/bioemu/sidechain_relax.py
@@ -192,7 +192,10 @@ def run_all_md(samples_all: list[mdtraj.Trajectory], md_protocol: MDProtocol) ->
             "Could not create MD setups for given system. Try running MD setup on reconstructed samples manually."
         )
 
-    equil_traj = mdtraj.Trajectory(np.concatenate([xyz[np.newaxis, ...] for xyz in equil_xyz], axis=0), samples_all[-1].top.subset(atom_idx))
+    equil_traj = mdtraj.Trajectory(
+        np.concatenate([xyz[np.newaxis, ...] for xyz in equil_xyz], axis=0),
+        samples_all[-1].top.subset(atom_idx),
+    )
     return equil_traj
 
 

--- a/src/bioemu/sidechain_relax.py
+++ b/src/bioemu/sidechain_relax.py
@@ -229,8 +229,8 @@ def main(
     samples_all_heavy = reconstruct_sidechains(samples)
 
     # write out sidechain reconstructed output
-    samples_all_heavy.save_xtc(f"{prefix}_sidechain_rec.xtc")
-    samples_all_heavy[0].save_pdb(f"{prefix}_sidechain_rec.pdb")
+    samples_all_heavy.save_xtc(os.path.join(outpath, f"{prefix}_sidechain_rec.xtc"))
+    samples_all_heavy[0].save_pdb(os.path.join(outpath, f"{prefix}_sidechain_rec.pdb"))
 
     # run MD equilibration if requested
     if md_equil:


### PR DESCRIPTION
Reconstructed sidechains with hpacker are currently dumped in the working directory instead on the specified `outpath` arg of `sidechain_relax.main`