### PR TITLE
chore: add `cache_so3_dir` to `sample.main`

### DIFF
--- a/src/bioemu/hpacker_setup/setup_hpacker.py
+++ b/src/bioemu/hpacker_setup/setup_hpacker.py
@@ -22,7 +22,8 @@ def ensure_hpacker_install(
     named `envname`
     """
     conda_root = get_conda_prefix()
-    conda_envs = os.listdir(os.path.join(conda_root, "envs"))
+    env_dir = os.path.join(conda_root, "envs")
+    conda_envs = os.listdir(os.path.join(conda_root, "envs")) if os.path.exists(env_dir) else []
 
     if envname not in conda_envs:
         logger.info("Setting up hpacker dependencies...")

--- a/src/bioemu/hpacker_setup/setup_hpacker.py
+++ b/src/bioemu/hpacker_setup/setup_hpacker.py
@@ -2,6 +2,8 @@ import logging
 import os
 import subprocess
 
+from bioemu.utils import get_conda_prefix
+
 HPACKER_INSTALL_SCRIPT = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "setup_sidechain_relax.sh"
 )
@@ -19,11 +21,7 @@ def ensure_hpacker_install(
     Ensures hpacker and its dependencies are installed under conda environment
     named `envname`
     """
-    conda_root = os.getenv("CONDA_ROOT", None)
-    if conda_root is None:
-        # Attempt $CONDA_PREFIX_1
-        conda_root = os.getenv("CONDA_PREFIX_1", None)
-    assert conda_root is not None, "conda required to install hpacker environment"
+    conda_root = get_conda_prefix()
     conda_envs = os.listdir(os.path.join(conda_root, "envs"))
 
     if envname not in conda_envs:

--- a/src/bioemu/sample.py
+++ b/src/bioemu/sample.py
@@ -74,6 +74,7 @@ def main(
     denoiser_type: SupportedDenoisersLiteral | None = "dpm",
     denoiser_config_path: str | Path | None = None,
     cache_embeds_dir: str | Path | None = None,
+    cache_so3_dir: str | Path | None = None,
     msa_host_url: str | None = None,
     filter_samples: bool = True,
 ) -> None:
@@ -95,6 +96,7 @@ def main(
         denoiser_type: Denoiser to use for sampling, if `denoiser_config_path` not specified. Comes in with default parameter configuration. Must be one of ['dpm', 'heun']
         denoiser_config_path: Path to the denoiser config, defining the denoising process.
         cache_embeds_dir: Directory to store MSA embeddings. If not set, this defaults to `COLABFOLD_DIR/embeds_cache`.
+        cache_so3_dir: Directory to store SO3 precomputations. If not set, this defaults to `~/sampling_so3_cache`.
         msa_host_url: MSA server URL. If not set, this defaults to colabfold's remote server. If sequence is an a3m file, this is ignored.
         filter_samples: Filter out unphysical samples with e.g. long bond distances or steric clashes.
     """
@@ -110,6 +112,9 @@ def main(
 
     with open(model_config_path) as f:
         model_config = yaml.safe_load(f)
+
+    if cache_so3_dir is not None:
+        model_config["sdes"]["node_orientations"]["cache_dir"] = cache_so3_dir
 
     # User may have provided an MSA file instead of a sequence. This will be used for embeddings.
     msa_file = sequence if str(sequence).endswith(".a3m") else None


### PR DESCRIPTION
This is useful for runners that do not have explicit access to their home directories (e.g., queueing systems in university clusters).

Fixes https://github.com/microsoft/bioemu/issues/96