### PR TITLE
fix: Install cuda dependencies for optional OpenMM package 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
     "pre-commit",
 ]
 md = [
-    "openmm==8.2.0",
+    "openmm[cuda12]==8.2.0",
     "pdb2pqr==3.4.1"
 ]
 

--- a/src/bioemu/hpacker_setup/setup_hpacker.py
+++ b/src/bioemu/hpacker_setup/setup_hpacker.py
@@ -22,7 +22,8 @@ def ensure_hpacker_install(
     named `envname`
     """
     conda_root = get_conda_prefix()
-    conda_envs = os.listdir(os.path.join(conda_root, "envs"))
+    env_dir = os.path.join(conda_root, "envs")
+    conda_envs = os.listdir(os.path.join(conda_root, "envs")) if os.path.exists(env_dir) else []
 
     if envname not in conda_envs:
         logger.info("Setting up hpacker dependencies...")

--- a/src/bioemu/hpacker_setup/setup_hpacker.py
+++ b/src/bioemu/hpacker_setup/setup_hpacker.py
@@ -2,6 +2,8 @@ import logging
 import os
 import subprocess
 
+from bioemu.utils import get_conda_prefix
+
 HPACKER_INSTALL_SCRIPT = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "setup_sidechain_relax.sh"
 )
@@ -19,11 +21,7 @@ def ensure_hpacker_install(
     Ensures hpacker and its dependencies are installed under conda environment
     named `envname`
     """
-    conda_root = os.getenv("CONDA_ROOT", None)
-    if conda_root is None:
-        # Attempt $CONDA_PREFIX_1
-        conda_root = os.getenv("CONDA_PREFIX_1", None)
-    assert conda_root is not None, "conda required to install hpacker environment"
+    conda_root = get_conda_prefix()
     conda_envs = os.listdir(os.path.join(conda_root, "envs"))
 
     if envname not in conda_envs:

--- a/src/bioemu/sample.py
+++ b/src/bioemu/sample.py
@@ -67,6 +67,7 @@ def main(
     sequence: str | Path,
     num_samples: int,
     output_dir: str | Path,
+    n_steps: int,
     batch_size_100: int = 10,
     model_name: str | None = "bioemu-v1.0",
     ckpt_path: str | Path | None = None,
@@ -143,6 +144,9 @@ def main(
 
     with open(denoiser_config_path) as f:
         denoiser_config = yaml.safe_load(f)
+
+    assert "N" in denoiser_config
+    denoiser_config["N"] = n_steps
     denoiser = hydra.utils.instantiate(denoiser_config)
 
     logger.info(


### PR DESCRIPTION
According to the installation guide, if we install openmm via PyPI we need to add the optional dependency selector `cudaXX`, where `XX` is the latest supported CUDA version by the user's machine.