### PR TITLE
chore: tie colabfold dir to the python executable

### DIFF
--- a/src/bioemu/get_embeds.py
+++ b/src/bioemu/get_embeds.py
@@ -48,11 +48,13 @@ def write_fasta(seqs: list[str], fasta_file: StrPath, ids: list[str] | None = No
 
 def _get_colabfold_dir() -> StrPath:
     """
-    Get colabfold environment folder
+    Get colabfold environment folder. Specific to the python executable being used.
     """
-    return os.environ.get(
+    parent_colabfold_dir = os.environ.get(
         "BIOEMU_COLABFOLD_DIR", os.path.join(os.path.expanduser("~"), ".bioemu_colabfold")
     )
+    exec_name = sys.executable.lstrip("/").replace("/", "_")
+    return os.path.join(parent_colabfold_dir, exec_name)
 
 
 def ensure_colabfold_install() -> str:

--- a/src/bioemu/hpacker_setup/setup_hpacker.py
+++ b/src/bioemu/hpacker_setup/setup_hpacker.py
@@ -2,6 +2,8 @@ import logging
 import os
 import subprocess
 
+from bioemu.utils import get_conda_prefix
+
 HPACKER_INSTALL_SCRIPT = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "setup_sidechain_relax.sh"
 )
@@ -19,11 +21,7 @@ def ensure_hpacker_install(
     Ensures hpacker and its dependencies are installed under conda environment
     named `envname`
     """
-    conda_root = os.getenv("CONDA_ROOT", None)
-    if conda_root is None:
-        # Attempt $CONDA_PREFIX_1
-        conda_root = os.getenv("CONDA_PREFIX_1", None)
-    assert conda_root is not None, "conda required to install hpacker environment"
+    conda_root = get_conda_prefix()
     conda_envs = os.listdir(os.path.join(conda_root, "envs"))
 
     if envname not in conda_envs:


### PR DESCRIPTION
To avoid having multiple installation of colabfold (with different interpreters) using the same venv.  