### PR TITLE
Setting N=50 as default in DPMsolver

### DIFF
--- a/src/bioemu/config/denoiser/dpm.yaml
+++ b/src/bioemu/config/denoiser/dpm.yaml
@@ -2,4 +2,4 @@ _target_: bioemu.shortcuts.dpm_solver
 _partial_: true
 eps_t: 0.001
 max_t: 0.99
-N: 30
+N: 50


### PR DESCRIPTION
After @josejimenezluna's analyses of the sampler and discussion with @YuuuXie I propose to set N=50 steps as default for the DPMsolver in order to get a high probability of valid samples:

![image](https://github.com/user-attachments/assets/6ef18868-9d79-4b5e-a63a-a44792f50195)
