### PR TITLE
fix: avoid globally enabling stackprinter

### DIFF
--- a/src/bioemu/sample.py
+++ b/src/bioemu/sample.py
@@ -11,7 +11,6 @@ from typing import Literal
 
 import hydra
 import numpy as np
-import stackprinter
 import torch
 import yaml
 from huggingface_hub import hf_hub_download
@@ -24,10 +23,11 @@ from .get_embeds import get_colabfold_embeds
 from .models import DiGConditionalScoreModel
 from .sde_lib import SDE
 from .seq_io import parse_sequence, write_fasta
-from .utils import count_samples_in_output_dir, format_npz_samples_filename
-
-stackprinter.set_excepthook(style="darkbg2")
-
+from .utils import (
+    count_samples_in_output_dir,
+    format_npz_samples_filename,
+    print_traceback_on_exception,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +62,7 @@ def maybe_download_checkpoint(
     return str(ckpt_path), str(model_config_path)
 
 
+@print_traceback_on_exception
 @torch.no_grad()
 def main(
     sequence: str | Path,

--- a/src/bioemu/utils.py
+++ b/src/bioemu/utils.py
@@ -1,7 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+import functools
 import os
+from collections.abc import Callable
 from pathlib import Path
+from typing import ParamSpec, TypeVar
+
+import stackprinter
 
 
 def format_npz_samples_filename(start_id: int, num_samples: int) -> str:
@@ -39,3 +44,21 @@ def get_conda_prefix() -> str:
         conda_root = os.getenv(conda_prefix_env_name, None)
     assert conda_root is not None, _conda_not_installed_errmsg
     return conda_root
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def print_traceback_on_exception(func: Callable[P, T]) -> Callable[P, T]:
+    """Wraps a function with stackprinter error logging."""
+
+    @functools.wraps(func)
+    def with_stackprint(*args: P.args, **kwargs: P.kwargs) -> T:
+        try:
+            return func(*args, **kwargs)
+        except:
+            stackprinter.show()
+            raise
+
+    return with_stackprint


### PR DESCRIPTION
Wrap the `main` function in `src/bioemu/sample.py` with a decorator that prints the stack trace on exception so that just importing `bioemu.sample` does not enable stackprinter.