### PR TITLE
Increase `max_file_size` in `pre-commit-config`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v4.4.0
   hooks:
   - id: check-added-large-files
-    args: [--maxkb=500, --enforce-all]
+    args: [--maxkb=6000, --enforce-all]
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 22.3.0


### PR DESCRIPTION
In order to add AFDB cluster definitions to paper (~5MB) on #109 