### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Sampling times will depend on sequence length and available infrastructure. The 
  |             300 |         40 |
  |             600 |        150 |
 
+Note by default, unphysical structures (steric clashes or chain discontinuities) will be filtered out, so you will typically get less samples in the output file than requested. The difference can be very large if your protein has large disordered regions which are very likely to produce clashes. If you want to get all generated samples in the output, irrespective of whether they are physically valid, use 'filter_samples=False'.
 
 > [!NOTE]
 > If you wish to use your own generated MSA instead of the ones retrieved via Colabfold, you can pass an A3M file containing the query sequence as the first row to the `sequence` argument. Additionally, the `msa_host_url` argument can be used to override the default Colabfold MSA query server. See [sample.py](./src/bioemu/sample.py) for more options.


### PR DESCRIPTION
Added a note that by default we filter out sample and there may be less samples at the output than requested, which may be significant for disordered proteins, and described option out to avoid that.