### PR TITLE
change default noise of dpmsolver to 0

### DIFF
--- a/src/bioemu/config/denoiser/dpm.yaml
+++ b/src/bioemu/config/denoiser/dpm.yaml
@@ -3,4 +3,4 @@ _partial_: true
 eps_t: 0.001
 max_t: 0.99
 N: 50
-noise: 0.5
+noise: 0.0


### PR DESCRIPTION
As @josejimenezluna mentioned, the previous PR of adding SDE version of DPMsolver changes the default setting. This will change the behavior. As we only uses the SDE version of DPMsolver for test right now, I update the default to noise=0, such that it's still the original ODE sampler.

@ludwigwinkler for your usage, you can manually change the `dpm.yaml` noise value to 0.5 when you need the SDE version.