### PR TITLE
fix: incorrect hpacker environment variable name in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ python -m bioemu.sidechain_relax --pdb-path path/to/topology.pdb --xtc-path path
 
 
 > [!NOTE]
-> The first time this module is invoked, it will attempt to install `hpacker` and its dependencies into a separate `hpacker` conda environment. If you wish for it to be installed in a different location, please set the `HPACKER_ENVNAME` environment variable before using this module for the first time.
+> The first time this module is invoked, it will attempt to install `hpacker` and its dependencies into a separate `hpacker` conda environment. If you wish for it to be installed in a different location, please set the `HPACKER_ENV_NAME` environment variable before using this module for the first time.
 
 By default, side-chain reconstruction and local energy minimization are performed (no full MD integration for efficiency reasons).
 Note that the runtime of this code scales with the size of the system.


### PR DESCRIPTION
As pointed out in https://github.com/microsoft/bioemu/issues/150