### PR TITLE
Use KDTree instead of mdtraj.compute_contacts in _filter_unphysical_traj_masks to mitigate MemoryError and improve performance

### DIFF
--- a/src/bioemu/convert_chemgraph.py
+++ b/src/bioemu/convert_chemgraph.py
@@ -294,6 +294,38 @@ def _adjust_oxygen_pos(
     return atom_37
 
 
+def _get_frames_non_clash_kdtree(
+    traj: mdtraj.Trajectory, clash_distance_angstrom: float
+) -> np.ndarray:
+    """Faster check for clashes using kd-trees. This version is faster than _get_frames_non_clash_mdtraj when there are many atoms, and also requires less memory."""
+    frames_non_clash = np.full(len(traj), True, dtype=bool)
+    atom2res = np.asarray([a.residue.index for a in traj[0].topology._atoms])
+    # Do not use 'enumerate(traj)' because if traj.time is missing or too short, it won't look at all the frames.
+    for i in range(len(traj)):
+        frame_kdtree = KDTree(traj.xyz[i, :, :])
+        frame_atom_pairs = frame_kdtree.query_pairs(
+            r=mdtraj.utils.in_units_of(clash_distance_angstrom, "angstrom", "nanometers")
+        )
+        for atom_pair in frame_atom_pairs:
+            # mdtraj.compute_contacts ignores the residue pairs (i,i+1) and (i,i+2)
+            if atom2res[atom_pair[1]] - atom2res[atom_pair[0]] > 2:
+                frames_non_clash[i] = False
+                break
+    return frames_non_clash
+
+
+def _get_frames_non_clash_mdtraj(
+    traj: mdtraj.Trajectory, clash_distance_angstrom: float
+) -> np.ndarray:
+    """Check for clashes using mdtraj.compute_contacts. This version is faster than _get_frames_non_clash_kdtree when there are few atoms."""
+    res_distances, _ = mdtraj.compute_contacts(traj, periodic=False)
+    frames_non_clash = np.all(
+        mdtraj.utils.in_units_of(res_distances, "nanometers", "angstrom") > clash_distance_angstrom,
+        axis=1,
+    )
+    return frames_non_clash
+
+
 def _filter_unphysical_traj_masks(
     traj: mdtraj.Trajectory,
     max_ca_seq_distance: float = 4.5,
@@ -339,25 +371,9 @@ def _filter_unphysical_traj_masks(
 
     # Clashes between any two atoms from different residues
     if traj.n_residues <= 100:
-        rest_distances, _ = mdtraj.compute_contacts(traj, periodic=False)
-        frames_non_clash = np.all(
-            mdtraj.utils.in_units_of(rest_distances, "nanometers", "angstrom") > clash_distance,
-            axis=1,
-        )
+        frames_non_clash = _get_frames_non_clash_mdtraj(traj, clash_distance)
     else:
-        frames_non_clash = np.full(len(traj), True, dtype=bool)
-        atom2res = np.asarray([a.residue.index for a in traj[0].topology._atoms])
-        for i, frame in enumerate(traj):
-            frame_kdtree = KDTree(frame.xyz[0, :, :])
-            frame_atom_pairs = frame_kdtree.query_pairs(
-                r=mdtraj.utils.in_units_of(clash_distance, "angstrom", "nanometers")
-            )
-
-            for atom_pair in frame_atom_pairs:
-                # mdtraj.compute_contacts ignores the residue pairs (i,i+1) and (i,i+2)
-                if atom2res[atom_pair[1]] - atom2res[atom_pair[0]] > 2:
-                    frames_non_clash[i] = False
-                    break
+        frames_non_clash = _get_frames_non_clash_kdtree(traj, clash_distance)
     return frames_match_ca_seq_distance, frames_match_cn_seq_distance, frames_non_clash
 
 

--- a/src/bioemu/convert_chemgraph.py
+++ b/src/bioemu/convert_chemgraph.py
@@ -339,18 +339,17 @@ def _filter_unphysical_traj_masks(
 
     # Clashes between any two atoms from different residues
     frames_non_clash = np.full(len(traj), True, dtype=bool)
+    atom2res = np.asarray([a.residue.index for a in traj[0].topology._atoms])
+
     for i, frame in enumerate(traj):
         frame_kdtree = KDTree(frame.xyz[0, :, :])
-        frame_res_pairs = frame_kdtree.query_pairs(r=0.1 * clash_distance)
+        frame_atom_pairs = frame_kdtree.query_pairs(r=0.1 * clash_distance)
 
-        for res_pair in frame_res_pairs:
+        for atom_pair in frame_atom_pairs:
             # mdtraj.compute_contacts ignores the residue pairs (i,i+1) and (i,i+2)
-            ri = frame.topology.atom(res_pair[0]).residue.index
-            rj = frame.topology.atom(res_pair[1]).residue.index
-            if rj - ri < 3:
-                pass
-            else:
+            if atom2res[atom_pair[1]] - atom2res[atom_pair[0]] > 2:
                 frames_non_clash[i] = False
+                break
     return frames_match_ca_seq_distance, frames_match_cn_seq_distance, frames_non_clash
 
 

--- a/src/bioemu/convert_chemgraph.py
+++ b/src/bioemu/convert_chemgraph.py
@@ -343,7 +343,9 @@ def _filter_unphysical_traj_masks(
 
     for i, frame in enumerate(traj):
         frame_kdtree = KDTree(frame.xyz[0, :, :])
-        frame_atom_pairs = frame_kdtree.query_pairs(r=0.1 * clash_distance)
+        frame_atom_pairs = frame_kdtree.query_pairs(
+            r=mdtraj.utils.in_units_of(clash_distance, "angstrom", "nanometers")
+        )
 
         for atom_pair in frame_atom_pairs:
             # mdtraj.compute_contacts ignores the residue pairs (i,i+1) and (i,i+2)

--- a/src/bioemu/convert_chemgraph.py
+++ b/src/bioemu/convert_chemgraph.py
@@ -3,10 +3,10 @@
 import logging
 from pathlib import Path
 
-from scipy.spatial import KDTree
 import mdtraj
 import numpy as np
 import torch
+from scipy.spatial import KDTree
 
 from .openfold.np import residue_constants
 from .openfold.np.protein import Protein, to_pdb


### PR DESCRIPTION
Hi, first of all thanks for the project!

I was running bioemu for a structure with 994 residues for 10,000 samples. The model and side chain generation ran successfully but I got  `MemoryError: Unable to allocate 445. GiB for an array with shape (10000, 11954402) and data type float32` in the `save_pdb_and_xtc` function. 

After some digging, I found that the error was caused by the `mdtraj.compute_contacts` function that is used to find clashes in the `_filter_unphysical_traj_masks` function. As the `mdtraj.compute_contacts` function works by first calculating the distances between atoms for each frame of the trajectory (ignoring i+1th and i+2th residues for residue i), it tries to create a huge array with a shape `(10000, 11954402)`.  To avoid creating this huge array, I  processed each frame one by one.

Also, since  we are not directly interested in the distances between all atom pairs but whether if there are any clashes, I have used KDTree to check if there are any clashes without directly computing the distance matrices, which improved the performance of finding clashes dramatically as you can see from the figure below where I found the clashes for the first N frames of the original trajectory. The `mdtraj.compute_contacts` can only find clashes up to 4000 frames as it gaves memory errors after that.

<img width="640" height="480" alt="figure" src="https://github.com/user-attachments/assets/783bf7b6-d84c-4afb-92a7-cfaec4c3ca9d" />
