### PR TITLE
fix: mdtraj.join call in reconstruct_sidechains

### DIFF
--- a/src/bioemu/sidechain_relax.py
+++ b/src/bioemu/sidechain_relax.py
@@ -105,7 +105,7 @@ def reconstruct_sidechains(traj: mdtraj.Trajectory) -> mdtraj.Trajectory:
         for n, frame in enumerate(reconstructed[1:]):
             if frame.topology == concatenated.topology:
                 concatenated = mdtraj.join(
-                    concatenated, frame, check_topology=False
+                    [concatenated, frame], check_topology=False
                 )  # already checked
             else:
                 logger.warning(f"skipping frame {n+1} due to different reconstructed topology")


### PR DESCRIPTION
Hi, in the `reconstruct_sidechains` function if the first `mdtraj.join` call fails, each frame of the trajectory is joined one by one using `mdtraj.join(concatenated, frame, check_topology=False)`  call. But as the `mdtraj.join` function needs the frames as an iterable in the first argument not as multiple argument (https://mdtraj.org/1.9.4/api/generated/mdtraj.join.html), the call fails with `TypeError: join() got multiple values for argument 'check_topology'`.  To fix this, I have changed `mdtraj.join(concatenated, frame, check_topology=False)`  to `mdtraj.join([concatenated, frame], check_topology=False)`.
