### PR TITLE
Speed up md-relaxation test

### DIFF
--- a/src/bioemu/md_utils.py
+++ b/src/bioemu/md_utils.py
@@ -143,7 +143,7 @@ def _add_constraint_force(system: mm.System, modeller: app.Modeller, k: float) -
 def _do_equilibration(
     simulation: app.Simulation,
     integrator: mm.Integrator,
-    init_timesteps_ps: list[float],
+    init_timesteps_ps: tuple[float, ...],
     integrator_timestep_ps: float,
     simtime_ns_nvt_equil: float,
     simtime_ns_npt_equil: float,
@@ -169,7 +169,7 @@ def _do_equilibration(
     """
     # start with tiny integrator steps and increase to target integrator step
     for init_int_ts_ps in tqdm(
-        init_timesteps_ps + [integrator_timestep_ps],
+        init_timesteps_ps + (integrator_timestep_ps,),
         desc="small timestep pre-equilibration",
         leave=False,
     ):

--- a/tests/test_mdrelax.py
+++ b/tests/test_mdrelax.py
@@ -36,6 +36,8 @@ def run_one_md_nointegration(
         simtime_ns_nvt_equil=0.0,
         simtime_ns_npt_equil=0.0,
         simtime_ns=0.0,
+        local_minimizer_tolerance=5000 * u.kilojoule / u.mole / u.nanometer,
+        init_timesteps_ps=tuple(),
     )
 
 


### PR DESCRIPTION
This PR removes the pre-equilibration steps at test time, and reduces local energy minimizer tolerance. Speedup is from 24s to ~4.5s on my sandbox [edit: from > 660s to 2.8s on CI] for `test_mdrelax_integration` in `tests/test_mdrelax.py`. 