### PR TITLE
chore: update openmm version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@
     "pytest-cov",
     "pre-commit",
   ]
-  md = ["openmm[cuda12]==8.2.0"]
+  md = ["openmm[cuda12]==8.4.0"]
 
 [tool.black]
   line-length = 100


### PR DESCRIPTION
Old openMM version seems broken on pypi, compare linked issue below. Upgrading to newest one.

Test with a fresh environment succeeded.
```bash
mamba create -n bioemu-test python==3.12
mamba activate bioemu-test
pip install ".[md]"

python -m openmm.testInstallation
```

closes #191 