### PR TITLE
fix: use unified diff format for colabfold patches

### DIFF
--- a/src/bioemu/colabfold_setup/batch.patch
+++ b/src/bioemu/colabfold_setup/batch.patch
@@ -1,4 +1,13 @@
-487a488
->                 np.save(files.get("single_repr_evo", "npy"), result["representations_evo"]["single"])
-489a491
->                 np.save(files.get("pair_repr_evo", "npy"), result["representations_evo"]["pair"])
+--- colabfold/batch.py	2026-02-01 16:37:58.665434920 +0000
++++ colabfold/batch.py	2026-02-01 16:38:09.640747260 +0000
+@@ -470,8 +470,10 @@
+                     pickle.dump(result, handle)
+             if save_single_representations:
+                 np.save(files.get("single_repr","npy"),result["representations"]["single"])
++                np.save(files.get("single_repr_evo", "npy"), result["representations_evo"]["single"])
+             if save_pair_representations:
+                 np.save(files.get("pair_repr","npy"),result["representations"]["pair"])
++                np.save(files.get("pair_repr_evo", "npy"), result["representations_evo"]["pair"])
+ 
+             # write an easy-to-use format (pAE and pLDDT)
+             with files.get("scores","json").open("w") as handle:

--- a/src/bioemu/colabfold_setup/modules.patch
+++ b/src/bioemu/colabfold_setup/modules.patch
@@ -1,14 +1,11 @@
-146c146
-<     ret = {'representations':representations}
----
->     ret = {'representations':representations, 'representations_evo': representations}
-173d172
-< 
-181d179
-< 
-216d213
-< 
-317d313
-< 
-2092d2087
-< 
+--- alphafold/model/modules.py	2026-02-01 16:33:40.892311392 +0000
++++ alphafold/model/modules.py	2026-02-01 16:33:40.894440639 +0000
+@@ -143,7 +143,7 @@
+       if not head_config.weight: continue
+       heads[name] = head_factory[name](head_config, self.global_config)
+     
+-    ret = {'representations':representations}
++    ret = {'representations':representations, 'representations_evo': representations}
+     for name, head in heads.items():
+       if name in ('predicted_lddt', 'predicted_aligned_error'):
+         continue

--- a/src/bioemu/colabfold_setup/setup.sh
+++ b/src/bioemu/colabfold_setup/setup.sh
@@ -25,9 +25,9 @@ ${BASE_PYTHON} -m uv pip install --python ${VENV_FOLDER}/bin/python --force-rein
 # Patch colabfold install
 echo "Patching colabfold installation..."
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-SITE_PACKAGES_DIR=${VENV_FOLDER}/lib/python3.*/site-packages
-patch ${SITE_PACKAGES_DIR}/alphafold/model/modules.py ${SCRIPT_DIR}/modules.patch
-patch ${SITE_PACKAGES_DIR}/colabfold/batch.py ${SCRIPT_DIR}/batch.patch
+SITE_PACKAGES_DIR=$(echo ${VENV_FOLDER}/lib/python3.*/site-packages)
+patch -p0 -d ${SITE_PACKAGES_DIR} < ${SCRIPT_DIR}/modules.patch
+patch -p0 -d ${SITE_PACKAGES_DIR} < ${SCRIPT_DIR}/batch.patch
 
 touch ${VENV_FOLDER}/.COLABFOLD_PATCHED
 echo "Colabfold installation complete!"


### PR DESCRIPTION
The colabfold patches were in an incompatible format that `patch` silently rejected, causing setup to complete without actually patching the installation.

## Changes

- **Converted patches to unified diff format**: `modules.patch` and `batch.patch` now use standard unified diff with proper headers
- **Fixed patch application**: Use `patch -p0 -d ${SITE_PACKAGES_DIR} < file` instead of piping through stdin
- **Fixed path expansion**: Properly expand `SITE_PACKAGES_DIR` glob with `$(echo ...)` before use

## What gets patched

```python
# modules.patch: Add representations_evo to return dict
-ret = {'representations': representations}
+ret = {'representations': representations, 'representations_evo': representations}

# batch.patch: Save evolutionary representations alongside standard ones
 np.save(files.get("single_repr", "npy"), result["representations"]["single"])
+np.save(files.get("single_repr_evo", "npy"), result["representations_evo"]["single"])
```


TO DO:
- [ ] double check with fresh docker.