### PR TITLE
Luwinkler/fkc steering

### DIFF
--- a/notebooks/fkc_steering.py
+++ b/notebooks/fkc_steering.py
@@ -1,0 +1,232 @@
+"""FKC steering toy example using the dpm_solver_fkc sampler.
+
+Demonstrates Feynman-Kac Controlled (FKC) steering on a 1D Gaussian Mixture Model.
+A quadratic potential biases the GMM, and we compare steered samples to the
+analytically computed ground truth distribution.
+"""
+
+import logging
+import warnings
+
+# Suppress expected warnings for 1D toy setup
+logging.basicConfig(level=logging.ERROR)
+warnings.filterwarnings("ignore", message=".*Bio.pairwise2.*")
+
+import matplotlib.pyplot as plt
+import torch
+import torch.nn as nn
+from torch_geometric.data import Batch
+
+from bioemu.chemgraph import ChemGraph
+from bioemu.sde_lib import CosineVPSDE
+from bioemu.so3_sde import DiGSO3SDE
+from bioemu.steering.dpm_fkc import dpm_solver_fkc
+from bioemu.toy_gmm import TimeDependentGMM1D
+
+# ============================================================
+# 1. Setup: GMM target distribution + SDE scheduler
+# ============================================================
+
+sde = CosineVPSDE()
+
+gmm = TimeDependentGMM1D(
+    mu1=torch.tensor([-1.0]),
+    mu2=torch.tensor([2.0]),
+    sigma1=1,
+    sigma2=0.5,
+    weight1=0.9,
+    scheduler=sde,
+)
+
+
+# ============================================================
+# 2. Score model wrapper (makes GMM score compatible with get_score)
+# ============================================================
+
+
+class GMMScoreWrapper(nn.Module):
+    """Wraps TimeDependentGMM1D to conform to the bioemu score model interface.
+
+    ``get_score()`` divides the model output by ``pos_std``, so this wrapper
+    returns ``analytical_score × std`` for pos and zeros for SO3.
+    """
+
+    def __init__(self, gmm: TimeDependentGMM1D, pos_sde: CosineVPSDE):
+        super().__init__()
+        self.gmm = gmm
+        self.pos_sde = pos_sde
+        # Dummy parameter so .to(device) works
+        self.dummy = nn.Parameter(torch.zeros(1))
+
+    def forward(self, batch, t):
+        # Extract 1D positions (first coordinate of each node)
+        x = batch.pos[:, 0:1]  # [total_nodes, 1]
+        t_per_node = t[batch.batch]
+
+        # Analytical score from GMM
+        score_1d = self.gmm.score(x, t_per_node)  # [total_nodes, 1]
+
+        # get_score divides by std — pre-multiply to cancel
+        _, pos_std = self.pos_sde.marginal_prob(
+            x=torch.ones_like(batch.pos), t=t, batch_idx=batch.batch
+        )
+
+        # Embed 1D score into 3D: [score × std, 0, 0]
+        pos_output = torch.zeros_like(batch.pos) + self.dummy * 0
+        pos_output[:, 0:1] = score_1d * pos_std[:, 0:1]
+
+        return {
+            "pos": pos_output,
+            "node_orientations": torch.zeros(
+                batch.pos.shape[0], 3, device=batch.pos.device
+            )
+            + self.dummy * 0,
+        }
+
+
+# ============================================================
+# 3. Quadratic steering potential
+# ============================================================
+
+POTENTIAL_K = 1.0
+POTENTIAL_CENTER = 2.0
+
+
+class QuadraticPotential:
+    """Quadratic potential U(x) = k/2 * (x - center)².
+
+    Receives Cα positions in Å (the steering code multiplies by 10), so
+    divides by 10 to recover the GMM-scale coordinate before computing U.
+    """
+
+    def __init__(self, k: float = POTENTIAL_K, center: float = POTENTIAL_CENTER):
+        self.k = k
+        self.center = center
+
+    def __call__(self, Ca_pos: torch.Tensor, *, t=None, sequence=None) -> torch.Tensor:
+        # Ca_pos: [batch_size, seq_length, 3] in Å
+        x = Ca_pos.reshape(Ca_pos.shape[0], -1)[:, 0] / 10.0  # back to GMM units
+        return 0.5 * self.k * (x - self.center) ** 2
+
+
+# ============================================================
+# 4. Batch creation helper
+# ============================================================
+
+
+def make_toy_batch(n_samples: int) -> Batch:
+    """Create a Batch of 1-residue ChemGraph objects for the 1D toy problem."""
+    data_list = []
+    for i in range(n_samples):
+        g = ChemGraph(
+            pos=torch.zeros(1, 3),
+            node_orientations=torch.eye(3).unsqueeze(0),
+            edge_index=torch.zeros(2, 0, dtype=torch.long),
+            single_embeds=torch.zeros(1, 1),
+            pair_embeds=torch.zeros(1, 1),
+            sequence="A",
+            system_id=f"toy_{i}",
+            node_labels=torch.zeros(1, dtype=torch.long),
+        )
+        data_list.append(g)
+    return Batch.from_data_list(data_list)
+
+
+# ============================================================
+# 5. Ground truth: biased distribution
+# ============================================================
+
+x_grid = torch.linspace(-6, 8, 1000)
+t_zero = torch.zeros(len(x_grid))
+
+with torch.no_grad():
+    log_gmm = gmm.log_prob(x_grid.unsqueeze(-1), t_zero)
+    log_boltzmann = -0.5 * POTENTIAL_K * (x_grid - POTENTIAL_CENTER) ** 2
+
+    # Biased distribution: GMM(x) * exp(-U(x))
+    log_biased = log_gmm + log_boltzmann
+    biased_unnorm = torch.exp(log_biased - log_biased.max())
+    dx = x_grid[1] - x_grid[0]
+    biased_pdf = biased_unnorm / (biased_unnorm.sum() * dx)
+
+    # Unbiased GMM for comparison
+    gmm_unnorm = torch.exp(log_gmm - log_gmm.max())
+    gmm_pdf = gmm_unnorm / (gmm_unnorm.sum() * dx)
+
+assert torch.isclose(biased_pdf.sum() * dx, torch.tensor(1.0), atol=1e-3), \
+    f"Biased PDF does not integrate to 1: {(biased_pdf.sum() * dx).item():.6f}"
+assert torch.isclose(gmm_pdf.sum() * dx, torch.tensor(1.0), atol=1e-3), \
+    f"GMM PDF does not integrate to 1: {(gmm_pdf.sum() * dx).item():.6f}"
+
+# ============================================================
+# 6. Run dpm_solver_fkc and plot
+# ============================================================
+
+N_SAMPLES = 20_000
+N_STEPS = 100
+NOISE_SCALE = 1.0
+
+sdes = {
+    "pos": CosineVPSDE(),
+    "node_orientations": DiGSO3SDE(num_sigma=10, num_omega=10, l_max=10),
+}
+
+score_model = GMMScoreWrapper(gmm, sde)
+potential = QuadraticPotential(k=POTENTIAL_K, center=POTENTIAL_CENTER)
+batch = make_toy_batch(N_SAMPLES)
+
+torch.manual_seed(42)
+result_batch, log_weights = dpm_solver_fkc(
+    sdes=sdes,
+    batch=batch,
+    N=N_STEPS,
+    score_model=score_model,
+    max_t=0.99,
+    eps_t=0.01,
+    device=torch.device("cpu"),
+    fk_potentials=[potential],
+    steering_config={"num_particles": 100, "ess_threshold": 0.8},
+    noise=NOISE_SCALE,
+    use_x0_for_reward=False,
+)
+
+steered_samples = result_batch.pos[:, 0].detach().cpu()
+
+# --- Compute MAE between steered sample density and ground truth ---
+import numpy as np
+
+# Build a density estimate on the same grid used for ground truth
+bin_edges = np.linspace(x_grid[0].item(), x_grid[-1].item(), len(x_grid) + 1)
+hist_counts, _ = np.histogram(steered_samples.numpy(), bins=bin_edges, density=True)
+# hist_counts has len(x_grid) entries; align with grid centres
+steered_density = torch.tensor(hist_counts, dtype=torch.float32)
+mae = (steered_density - biased_pdf).abs().mean().item()
+print(f"MAE between steered density and ground truth: {mae:.4f}")
+
+# --- Plot ---
+fig, ax = plt.subplots(figsize=(10, 6))
+ax.hist(steered_samples.numpy(), bins=30, density=True, alpha=0.5, color="steelblue",
+        label="FKC Steered Samples")
+ax.plot(x_grid.numpy(), gmm_pdf.numpy(), "b--", linewidth=2, label="Unbiased GMM")
+ax.plot(x_grid.numpy(), biased_pdf.numpy(), "r-", linewidth=2,
+        label=r"Ground Truth: GMM$(x) \times \exp(-U(x))$")
+
+# Potential on secondary y-axis
+ax2 = ax.twinx()
+U = 0.5 * POTENTIAL_K * (x_grid - POTENTIAL_CENTER) ** 2
+ax2.plot(x_grid.numpy(), U.numpy(), "g-.", linewidth=1.5, alpha=0.7,
+         label=r"$U(x)=\frac{k}{2}(x-c)^2$")
+ax2.set_ylabel("Potential U(x)", color="green")
+ax2.set_ylim(0, 50)
+ax2.tick_params(axis="y", labelcolor="green")
+ax2.legend(loc="upper left")
+ax.set_xlabel("x")
+ax.set_ylabel("Density")
+ax.set_title(
+    f"FKC Steering with Quadratic Potential "
+    f"(k={POTENTIAL_K}, center={POTENTIAL_CENTER}, MAE={mae:.4f})"
+)
+ax.legend()
+plt.tight_layout()
+plt.savefig("fkc_steering_result.png", dpi=150)
+plt.show()

--- a/src/bioemu/toy_gmm.py
+++ b/src/bioemu/toy_gmm.py
@@ -1,0 +1,215 @@
+"""
+Gaussian Mixture Model utilities for 1D toy example.
+
+Adapted from enhancedsampling repo for use with bioemu framework.
+"""
+
+import torch
+import torch.nn as nn
+from torch.distributions import Normal
+
+from bioemu.steering import CollectiveVariable
+
+MU1 = -2.0
+MU2 = 3.0
+SIGMA1 = 0.5
+SIGMA2 = 0.5
+
+
+class TimeDependentGMM1D(nn.Module):
+    """
+    Time-dependent 1D Gaussian Mixture Model.
+
+    The data distribution at t=0 is a GMM with two modes.
+    At time t, the distribution evolves according to the forward SDE.
+    """
+
+    def __init__(
+        self,
+        mu1: torch.Tensor,
+        mu2: torch.Tensor,
+        sigma1: float = SIGMA1,
+        sigma2: float = SIGMA2,
+        weight1: float = 0.7,
+        scheduler=None,  # SDE scheduler (e.g., CosineVPSDE)
+    ):
+        super().__init__()
+        self.register_buffer("mu1", mu1)  # [1]
+        self.register_buffer("mu2", mu2)  # [1]
+        self.sigma1 = sigma1
+        self.sigma2 = sigma2
+        self.weight1 = weight1
+        self.weight2 = 1.0 - weight1
+
+        # Use provided scheduler (should be same as diffusion process)
+        self.scheduler = scheduler
+
+        # Log weights for numerical stability
+        self.register_buffer("log_w1", torch.log(torch.tensor(weight1)))
+        self.register_buffer("log_w2", torch.log(torch.tensor(1.0 - weight1)))
+
+    def log_prob(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        """
+        Compute log probability at time t.
+
+        Args:
+            x: [batch_size, 1] - positions
+            t: [batch_size] or scalar - time
+
+        Returns:
+            log_prob: [batch_size] - log probabilities
+        """
+        if x.dim() == 1:
+            x = x.unsqueeze(-1)
+
+        batch_size = x.shape[0]
+
+        # Handle time broadcasting
+        # if not isinstance(t, torch.Tensor):
+        #     t = torch.tensor(t, device=x.device)
+        if t.dim() == 0:
+            t = t.unsqueeze(0).expand(batch_size)
+
+        # Get marginal parameters at time t
+        if hasattr(self.scheduler, "marginal_prob"):
+            # CosineVPSDE or other SDE with marginal_prob method
+            seq_length = 1
+            dim = 1
+            ones = torch.ones(batch_size, seq_length, dim, device=x.device)
+            alpha_t, sigma_t = self.scheduler.marginal_prob(x=ones, t=t)
+            alpha_t = alpha_t.squeeze()  # [batch_size]
+            sigma_t = sigma_t.squeeze()  # [batch_size]
+        else:
+            # BetaSchedule fallback
+            alpha_t, sigma_t = self.scheduler.get_alpha_t_sigma_t(t)  # [batch_size]
+
+        # Compute marginal means and stds for each component
+        # mu_t = alpha_t * mu_0
+        mu1_t = alpha_t.unsqueeze(-1) * self.mu1  # [batch_size, 1]
+        mu2_t = alpha_t.unsqueeze(-1) * self.mu2  # [batch_size, 1]
+
+        # sigma_t^2 = sigma_0^2 * alpha_t^2 + sigma_noise^2
+        sigma1_t = torch.sqrt(self.sigma1**2 * alpha_t**2 + sigma_t**2).unsqueeze(
+            -1
+        )  # [batch_size, 1]
+        sigma2_t = torch.sqrt(self.sigma2**2 * alpha_t**2 + sigma_t**2).unsqueeze(
+            -1
+        )  # [batch_size, 1]
+
+        # Compute log probabilities for each component
+        log_prob1 = Normal(mu1_t, sigma1_t).log_prob(x).sum(dim=-1)  # [batch_size]
+        log_prob2 = Normal(mu2_t, sigma2_t).log_prob(x).sum(dim=-1)  # [batch_size]
+
+        # Use log-sum-exp trick for mixture
+        log_probs = torch.stack(
+            [log_prob1 + self.log_w1, log_prob2 + self.log_w2], dim=-1
+        )  # [batch_size, 2]
+
+        return torch.logsumexp(log_probs, dim=-1)  # [batch_size]
+
+    @torch.enable_grad()
+    def score(
+        self,
+        x: torch.Tensor,
+        t: torch.Tensor | None = None,
+        *,
+        create_graph: bool = False,
+    ) -> torch.Tensor:
+        """Compute score function using autograd: ∇_x log q(x_t).
+
+        By default this is a first-order quantity used for sampling only, so
+        the computation graph is not kept. When ``create_graph=True``, the
+        returned score retains its computation graph so that gradients of any
+        downstream quantity that depends on the score with respect to ``x`` or
+        ``t`` can be computed (i.e. enables second-order derivatives).
+        """
+
+        if create_graph:
+            # Use x directly (or a cloned version) without detaching so that
+            # the graph from log_prob to the original x is preserved.
+            x_var = x
+
+        else:
+            # Default: no higher-order derivatives required. Detach x to keep
+            # this computation inexpensive and side-effect free for callers that
+            # only need the score value.
+            x_var = x.clone().requires_grad_(True)
+
+        # Compute log probability of marginal distribution at time t
+        log_prob = self.log_prob(x_var, t)
+
+        # Sum log probabilities to get scalar for autograd (needed for gradient computation)
+        if log_prob.dim() > 0:
+            log_prob_sum = log_prob.sum()
+        else:
+            log_prob_sum = log_prob
+
+        # Compute gradient of log probability with respect to x
+        score = torch.autograd.grad(
+            outputs=log_prob_sum,
+            inputs=x_var,
+            create_graph=create_graph,
+            retain_graph=create_graph,  # TODO: make this an option
+        )[0]
+        return score
+
+    def sample(self, n_samples: int, t: float = 0.0) -> torch.Tensor:
+        """
+        Sample from the GMM at time t.
+
+        Args:
+            n_samples: number of samples
+            t: time (default 0 = data distribution)
+
+        Returns:
+            samples: [n_samples, 1]
+        """
+        device = self.mu1.device
+        t_tensor = torch.tensor(t, device=device)
+
+        # Sample component assignments
+        z = torch.rand(n_samples, device=device) < self.weight1
+
+        # Get marginal parameters
+        if hasattr(self.scheduler, "marginal_prob"):
+            # CosineVPSDE or other SDE with marginal_prob method
+            ones = torch.ones(1, 1, device=device)
+            t_batch = t_tensor.unsqueeze(0)
+            alpha_t, sigma_t = self.scheduler.marginal_prob(x=ones, t=t_batch)
+            alpha_t = alpha_t.squeeze()
+            sigma_t = sigma_t.squeeze()
+        else:
+            # BetaSchedule fallback
+            alpha_t, sigma_t = self.scheduler.get_alpha_t_sigma_t(t_tensor)
+
+        mu1_t = alpha_t * self.mu1
+        mu2_t = alpha_t * self.mu2
+        sigma1_t = torch.sqrt(self.sigma1**2 * alpha_t**2 + sigma_t**2)
+        sigma2_t = torch.sqrt(self.sigma2**2 * alpha_t**2 + sigma_t**2)
+
+        # Sample from each component
+        samples1 = mu1_t + sigma1_t * torch.randn(n_samples, 1, device=device)
+        samples2 = mu2_t + sigma2_t * torch.randn(n_samples, 1, device=device)
+
+        # Mix samples based on component assignments
+        samples = torch.where(z.unsqueeze(-1), samples1, samples2)
+        return samples
+
+    def energy(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        """Return negative log probability."""
+        return -self.log_prob(x, t)
+
+
+class ToyPosCV(CollectiveVariable):
+    """Minimal CV that extracts the first coordinate (scaled) from a ChemGraph.
+
+    The bioemu steering stack expects CVs to operate on `ChemGraph` objects; for the
+    1D toy we simply read the first scalar position. The positional inputs arrive as
+    Angstrom in the steering code (they are multiplied by 10 prior to the call),
+    so we divide by 10 to recover the original nm-scale variable used in sampling.
+    """
+
+    def compute_batch(self, pos: torch.Tensor, sequence: str) -> torch.Tensor:
+        # pos shape: [batch_size, L, D]; toy uses L=1, D=1
+        vals = pos.reshape(pos.shape[0], -1)[:, 0]  # scale back to nm
+        return vals

--- a/tests/steering/test_steering_numerically.py
+++ b/tests/steering/test_steering_numerically.py
@@ -1,0 +1,236 @@
+"""Numerical tests verifying that dpm_fkc and dpm_smc steer toward the correct distribution.
+
+Both samplers should produce samples from the biased distribution
+biased(x) ∝ GMM(x) × p(x), where p(x) = 1/Z exp(-U(x)) is the Boltzmann
+distribution induced by a quadratic potential U(x) = k/2 (x - center)².
+"""
+
+import logging
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch_geometric.data import Batch
+
+from bioemu.chemgraph import ChemGraph
+from bioemu.sde_lib import CosineVPSDE
+from bioemu.so3_sde import DiGSO3SDE
+from bioemu.toy_gmm import TimeDependentGMM1D
+
+# Suppress noisy warnings from 1D toy setup
+logging.disable(logging.WARNING)
+
+# ============================================================
+# Shared constants
+# ============================================================
+
+POTENTIAL_K = 1.0
+POTENTIAL_CENTER = 2.0
+N_SAMPLES = 4096
+N_STEPS = 100
+NOISE_SCALE = 1.0
+MAX_T = 0.99
+EPS_T = 0.01
+MAE_THRESHOLD = 0.05
+
+
+# ============================================================
+# Shared helpers
+# ============================================================
+
+
+def make_gmm_and_sde():
+    """Create the GMM target distribution and CosineVPSDE scheduler."""
+    sde = CosineVPSDE()
+    gmm = TimeDependentGMM1D(
+        mu1=torch.tensor([-2.0]),
+        mu2=torch.tensor([3.0]),
+        sigma1=0.5,
+        sigma2=0.5,
+        weight1=0.7,
+        scheduler=sde,
+    )
+    return gmm, sde
+
+
+def make_sdes():
+    """Create the SDEs dict required by the samplers."""
+    return {
+        "pos": CosineVPSDE(),
+        "node_orientations": DiGSO3SDE(num_sigma=10, num_omega=10, l_max=10),
+    }
+
+
+class GMMScoreWrapper(nn.Module):
+    """Wraps TimeDependentGMM1D to conform to the bioemu score model interface.
+
+    ``get_score()`` divides the model output by ``pos_std``, so this wrapper
+    returns ``analytical_score × std`` for pos and zeros for SO3.
+    """
+
+    def __init__(self, gmm: TimeDependentGMM1D, pos_sde: CosineVPSDE):
+        super().__init__()
+        self.gmm = gmm
+        self.pos_sde = pos_sde
+        self.dummy = nn.Parameter(torch.zeros(1))
+
+    def forward(self, batch, t):
+        x = batch.pos[:, 0:1]
+        t_per_node = t[batch.batch]
+        score_1d = self.gmm.score(x, t_per_node)
+
+        _, pos_std = self.pos_sde.marginal_prob(
+            x=torch.ones_like(batch.pos), t=t, batch_idx=batch.batch
+        )
+
+        pos_output = torch.zeros_like(batch.pos) + self.dummy * 0
+        pos_output[:, 0:1] = score_1d * pos_std[:, 0:1]
+
+        return {
+            "pos": pos_output,
+            "node_orientations": torch.zeros(
+                batch.pos.shape[0], 3, device=batch.pos.device
+            )
+            + self.dummy * 0,
+        }
+
+
+class QuadraticPotential:
+    """Quadratic potential U(x) = k/2 * (x - center)².
+
+    Divides by 10 to convert from Å (steering convention) to GMM units.
+    """
+
+    def __init__(self, k: float = POTENTIAL_K, center: float = POTENTIAL_CENTER):
+        self.k = k
+        self.center = center
+
+    def __call__(self, Ca_pos: torch.Tensor, *, t=None, sequence=None) -> torch.Tensor:
+        x = Ca_pos.reshape(Ca_pos.shape[0], -1)[:, 0] / 10.0
+        return 0.5 * self.k * (x - self.center) ** 2
+
+
+def make_toy_batch(n_samples: int) -> Batch:
+    """Create a Batch of 1-residue ChemGraph objects for the 1D toy problem."""
+    data_list = [
+        ChemGraph(
+            pos=torch.zeros(1, 3),
+            node_orientations=torch.eye(3).unsqueeze(0),
+            edge_index=torch.zeros(2, 0, dtype=torch.long),
+            single_embeds=torch.zeros(1, 1),
+            pair_embeds=torch.zeros(1, 1),
+            sequence="A",
+            system_id=f"toy_{i}",
+            node_labels=torch.zeros(1, dtype=torch.long),
+        )
+        for i in range(n_samples)
+    ]
+    return Batch.from_data_list(data_list)
+
+
+def compute_ground_truth_pdf(
+    gmm: TimeDependentGMM1D,
+    k: float = POTENTIAL_K,
+    center: float = POTENTIAL_CENTER,
+    x_min: float = -6.0,
+    x_max: float = 8.0,
+    n_points: int = 1000,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute the normalized biased PDF: biased(x) ∝ GMM(x) × p(x).
+
+    Returns (x_grid, biased_pdf).
+    """
+    x_grid = torch.linspace(x_min, x_max, n_points)
+    t_zero = torch.zeros(n_points)
+    dx = x_grid[1] - x_grid[0]
+
+    with torch.no_grad():
+        log_gmm = gmm.log_prob(x_grid.unsqueeze(-1), t_zero)
+
+        # Normalized Boltzmann p(x) = 1/Z exp(-U(x))
+        boltzmann_unnorm = torch.exp(-0.5 * k * (x_grid - center) ** 2)
+        boltzmann_pdf = boltzmann_unnorm / (boltzmann_unnorm.sum() * dx)
+
+        # Normalized GMM
+        gmm_unnorm = torch.exp(log_gmm - log_gmm.max())
+        gmm_pdf = gmm_unnorm / (gmm_unnorm.sum() * dx)
+
+        # Biased = GMM × p(x), renormalized
+        biased_unnorm = gmm_pdf * boltzmann_pdf
+        biased_pdf = biased_unnorm / (biased_unnorm.sum() * dx)
+
+    return x_grid, biased_pdf
+
+
+def compute_mae(samples: torch.Tensor, x_grid: torch.Tensor, target_pdf: torch.Tensor) -> float:
+    """Compute MAE between a histogram of samples and a target PDF on the same grid."""
+    bin_edges = np.linspace(x_grid[0].item(), x_grid[-1].item(), len(x_grid) + 1)
+    hist_counts, _ = np.histogram(samples.numpy(), bins=bin_edges, density=True)
+    sample_density = torch.tensor(hist_counts, dtype=torch.float32)
+    return (sample_density - target_pdf).abs().mean().item()
+
+
+# ============================================================
+# Tests
+# ============================================================
+
+
+def test_dpm_fkc():
+    """dpm_solver_fkc steers samples toward the biased distribution."""
+    from bioemu.steering.dpm_fkc import dpm_solver_fkc
+
+    gmm, sde = make_gmm_and_sde()
+    sdes = make_sdes()
+    score_model = GMMScoreWrapper(gmm, sde)
+    potential = QuadraticPotential()
+    batch = make_toy_batch(N_SAMPLES)
+    x_grid, biased_pdf = compute_ground_truth_pdf(gmm)
+
+    torch.manual_seed(42)
+    result_batch, _ = dpm_solver_fkc(
+        sdes=sdes,
+        batch=batch,
+        N=N_STEPS,
+        score_model=score_model,
+        max_t=MAX_T,
+        eps_t=EPS_T,
+        device=torch.device("cpu"),
+        fk_potentials=[potential],
+        steering_config={"num_particles": 128, "ess_threshold": 0.5},
+        noise=NOISE_SCALE,
+        use_x0_for_reward=False,
+    )
+
+    samples = result_batch.pos[:, 0].detach().cpu()
+    mae = compute_mae(samples, x_grid, biased_pdf)
+    assert mae < MAE_THRESHOLD, f"FKC MAE {mae:.4f} exceeds threshold {MAE_THRESHOLD}"
+
+
+def test_dpm_smc():
+    """dpm_solver_smc steers samples toward the biased distribution."""
+    from bioemu.steering.dpm_smc import dpm_solver_smc
+
+    gmm, sde = make_gmm_and_sde()
+    sdes = make_sdes()
+    score_model = GMMScoreWrapper(gmm, sde)
+    potential = QuadraticPotential()
+    batch = make_toy_batch(N_SAMPLES)
+    x_grid, biased_pdf = compute_ground_truth_pdf(gmm)
+
+    torch.manual_seed(42)
+    result_batch, _ = dpm_solver_smc(
+        sdes=sdes,
+        batch=batch,
+        N=N_STEPS,
+        score_model=score_model,
+        max_t=MAX_T,
+        eps_t=EPS_T,
+        device=torch.device("cpu"),
+        fk_potentials=[potential],
+        steering_config={"num_particles": 128, "ess_threshold": 0.5},
+        noise=NOISE_SCALE,
+    )
+
+    samples = result_batch.pos[:, 0].detach().cpu()
+    mae = compute_mae(samples, x_grid, biased_pdf)
+    assert mae < MAE_THRESHOLD, f"SMC MAE {mae:.4f} exceeds threshold {MAE_THRESHOLD}"


### PR DESCRIPTION
Add a bimodal Gaussian mixture model with an analytical score function.

Implements a toy steering example in `notebooks/fkc_steering.py`. 

Adds two numerical tests for for `dpm_fkc` and `dpm_smc` that simulates a large ensemble of samples to numerically match the analytically tractable (in 1D) biased target distribution. 