### PR TITLE
fix: include .sh files in package data and improve hpacker docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   linux:
-    runs-on: [self-hosted, 1ES.Pool=1ES-GHA-Pool-Small, 'JobId=ai4s-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}']
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, 1ES.Pool=1ES-GHA-Pool-Small, 'JobId=ai4s-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}']
     permissions:
       contents: read
       pull-requests: write

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ python -m bioemu.sidechain_relax --pdb-path path/to/topology.pdb --xtc-path path
 
 
 > [!NOTE]
-> The first time this module is invoked, it will attempt to install `hpacker` and its dependencies into a separate `hpacker` conda environment using a bundled setup script. If the automatic setup fails, you can install hpacker manually by following the instructions at [hpacker's repository](https://github.com/gvisani/hpacker) and creating a conda environment named `hpacker` (or a custom name set via the `HPACKER_ENV_NAME` environment variable).
+> The first time this module is invoked, it will attempt to install `hpacker` and its dependencies into a separate virtualenv using a bundled setup script. If the automatic setup fails, you can install hpacker manually by following the instructions at [hpacker's repository](https://github.com/gvisani/hpacker) and setting the `HPACKER_PYTHONBIN` environment variable to the path of the python executable where hpacker is installed.
 
 By default, side-chain reconstruction and local energy minimization are performed (no full MD integration for efficiency reasons).
 Note that the runtime of this code scales with the size of the system.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ python -m bioemu.sidechain_relax --pdb-path path/to/topology.pdb --xtc-path path
 
 
 > [!NOTE]
-> The first time this module is invoked, it will attempt to install `hpacker` and its dependencies into a separate `hpacker` conda environment. If you wish for it to be installed in a different location, please set the `HPACKER_ENV_NAME` environment variable before using this module for the first time.
+> The first time this module is invoked, it will attempt to install `hpacker` and its dependencies into a separate `hpacker` conda environment using a bundled setup script. If the automatic setup fails, you can install hpacker manually by following the instructions at [hpacker's repository](https://github.com/gvisani/hpacker) and creating a conda environment named `hpacker` (or a custom name set via the `HPACKER_ENV_NAME` environment variable).
 
 By default, side-chain reconstruction and local energy minimization are performed (no full MD integration for efficiency reasons).
 Note that the runtime of this code scales with the size of the system.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,4 +182,4 @@
   where = ["src"]
 
 [tool.setuptools.package-data]
-  "*" = ["*.md"]
+  "*" = ["*.md", "*.sh"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@
     "pytest-cov",
     "pre-commit",
   ]
-  md = ["openmm[cuda12]==8.4.0"]
+  md = ["openmm==8.4.0", "openmm-cuda-12==8.4.0"]
   cuda = [
     "jax[cuda12]==0.4.35",
     "nvidia-cuda-nvcc-cu12==12.8.93",

--- a/src/bioemu/__init__.py
+++ b/src/bioemu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.0"
+__version__ = "1.3.1a1"
 
 # Register the vendored-package import hook so that ``import alphafold`` and
 # ``import openfold`` resolve to src/_vendor/{alphafold,openfold}/.

--- a/src/bioemu/__init__.py
+++ b/src/bioemu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.1"
+__version__ = "1.3.1a2"
 
 # Register the vendored-package import hook so that ``import alphafold`` and
 # ``import openfold`` resolve to src/_vendor/{alphafold,openfold}/.

--- a/src/bioemu/__init__.py
+++ b/src/bioemu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.1a1"
+__version__ = "1.3.1"
 
 # Register the vendored-package import hook so that ``import alphafold`` and
 # ``import openfold`` resolve to src/_vendor/{alphafold,openfold}/.

--- a/src/bioemu/__init__.py
+++ b/src/bioemu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.1a2"
+__version__ = "1.3.1a3"
 
 # Register the vendored-package import hook so that ``import alphafold`` and
 # ``import openfold`` resolve to src/_vendor/{alphafold,openfold}/.

--- a/src/bioemu/__init__.py
+++ b/src/bioemu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.1a3"
+__version__ = "1.3.1"
 
 # Register the vendored-package import hook so that ``import alphafold`` and
 # ``import openfold`` resolve to src/_vendor/{alphafold,openfold}/.

--- a/src/bioemu/hpacker_setup/setup_hpacker.py
+++ b/src/bioemu/hpacker_setup/setup_hpacker.py
@@ -2,12 +2,10 @@ import logging
 import os
 import subprocess
 
-from bioemu.utils import get_conda_prefix
-
 HPACKER_INSTALL_SCRIPT = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "setup_sidechain_relax.sh"
 )
-HPACKER_DEFAULT_ENVNAME = "hpacker"
+HPACKER_DEFAULT_VENV_DIR = os.path.join(os.path.expanduser("~"), ".hpacker_venv")
 HPACKER_DEFAULT_REPO_DIR = os.path.join(os.path.expanduser("~"), ".hpacker")
 
 logging.basicConfig(level=logging.DEBUG)
@@ -15,20 +13,16 @@ logger = logging.getLogger(__name__)
 
 
 def ensure_hpacker_install(
-    envname: str = HPACKER_DEFAULT_ENVNAME, repo_dir: str = HPACKER_DEFAULT_REPO_DIR
+    venv_dir: str = HPACKER_DEFAULT_VENV_DIR, repo_dir: str = HPACKER_DEFAULT_REPO_DIR
 ) -> None:
     """
-    Ensures hpacker and its dependencies are installed under conda environment
-    named `envname`
+    Ensures hpacker and its dependencies are installed in a virtualenv
+    at `venv_dir`.
     """
-    conda_root = get_conda_prefix()
-    env_dir = os.path.join(conda_root, "envs")
-    conda_envs = os.listdir(os.path.join(conda_root, "envs")) if os.path.exists(env_dir) else []
-
-    if envname not in conda_envs:
+    if not os.path.isdir(venv_dir):
         logger.info("Setting up hpacker dependencies...")
         _install = subprocess.run(
-            ["bash", HPACKER_INSTALL_SCRIPT, envname, repo_dir],
+            ["bash", HPACKER_INSTALL_SCRIPT, venv_dir, repo_dir],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )

--- a/src/bioemu/hpacker_setup/setup_sidechain_relax.sh
+++ b/src/bioemu/hpacker_setup/setup_sidechain_relax.sh
@@ -1,16 +1,26 @@
 #!/bin/bash
 set -ex
 
-HPACKER_ENV_NAME="${1:-"hpacker"}"
-HPACKER_REPO_DIR="${2:-"~/.hpacker"}"
+HPACKER_VENV_DIR="${1:-"${HOME}/.hpacker_venv"}"
+HPACKER_REPO_DIR="${2:-"${HOME}/.hpacker"}"
 
+# Clone the hpacker repo if it doesn't already exist
+if [ ! -d "${HPACKER_REPO_DIR}" ]; then
+    git clone https://github.com/gvisani/hpacker.git "${HPACKER_REPO_DIR}"
+fi
 
-# clone and install the hpacker code. This will install into a separate environment
-git clone https://github.com/gvisani/hpacker.git ${HPACKER_REPO_DIR}
-conda create -n $HPACKER_ENV_NAME --no-default-packages -y
-eval "$(conda shell.bash hook)"
-conda activate $HPACKER_ENV_NAME
-conda env update -f ${HPACKER_REPO_DIR}/env.yaml -n $HPACKER_ENV_NAME
+# Create a virtualenv for hpacker
+python3 -m venv "${HPACKER_VENV_DIR}"
+source "${HPACKER_VENV_DIR}/bin/activate"
 
-# non-editable installation seems broken (https://github.com/gvisani/hpacker/issues/2)
-pip install -e ${HPACKER_REPO_DIR}/
+# Install PyTorch (CUDA 11.8) from pytorch.org
+# See https://pytorch.org/get-started/previous-versions/
+# For CPU-only, replace with:
+#   pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install torch --index-url https://download.pytorch.org/whl/cu118
+
+# Install remaining hpacker dependencies
+pip install biopython==1.81 tqdm==4.67.1 progress==1.6 h5py==3.13.0 hdf5plugin==5.1.0 sqlitedict==2.1.0 'numpy<2' e3nn==0.5.0 mkl==2024.0
+
+# Install hpacker package
+pip install "${HPACKER_REPO_DIR}/"

--- a/src/bioemu/sidechain_relax.py
+++ b/src/bioemu/sidechain_relax.py
@@ -15,8 +15,8 @@ import typer
 from tqdm.auto import tqdm
 
 from bioemu.hpacker_setup.setup_hpacker import (
-    HPACKER_DEFAULT_ENVNAME,
     HPACKER_DEFAULT_REPO_DIR,
+    HPACKER_DEFAULT_VENV_DIR,
     ensure_hpacker_install,
 )
 from bioemu.md_utils import (
@@ -27,12 +27,11 @@ from bioemu.md_utils import (
     _run_and_write,
     _switch_off_constraints,
 )
-from bioemu.utils import get_conda_prefix
 
 logger = logging.getLogger(__name__)
 typer_app = typer.Typer(pretty_exceptions_enable=False)
 
-HPACKER_ENVNAME = os.getenv("HPACKER_ENV_NAME", HPACKER_DEFAULT_ENVNAME)
+HPACKER_VENV_DIR = os.getenv("HPACKER_VENV_DIR", HPACKER_DEFAULT_VENV_DIR)
 HPACKER_REPO_DIR = os.getenv("HPACKER_REPO_DIR", HPACKER_DEFAULT_REPO_DIR)
 
 
@@ -44,12 +43,10 @@ class MDProtocol(str, Enum):
 def _run_hpacker(protein_pdb_in: str, protein_pdb_out: str) -> None:
     """run hpacker in its environment."""
     # make sure that hpacker env is set up
-    ensure_hpacker_install(envname=HPACKER_ENVNAME, repo_dir=HPACKER_REPO_DIR)
+    ensure_hpacker_install(venv_dir=HPACKER_VENV_DIR, repo_dir=HPACKER_REPO_DIR)
 
     _default_hpacker_pythonbin = os.path.join(
-        get_conda_prefix(),
-        "envs",
-        HPACKER_ENVNAME,
+        HPACKER_VENV_DIR,
         "bin",
         "python",
     )

--- a/src/bioemu/sidechain_relax.py
+++ b/src/bioemu/sidechain_relax.py
@@ -42,15 +42,19 @@ class MDProtocol(str, Enum):
 
 def _run_hpacker(protein_pdb_in: str, protein_pdb_out: str) -> None:
     """run hpacker in its environment."""
-    # make sure that hpacker env is set up
-    ensure_hpacker_install(venv_dir=HPACKER_VENV_DIR, repo_dir=HPACKER_REPO_DIR)
 
-    _default_hpacker_pythonbin = os.path.join(
-        HPACKER_VENV_DIR,
-        "bin",
-        "python",
-    )
-    hpacker_pythonbin = os.getenv("HPACKER_PYTHONBIN", _default_hpacker_pythonbin)
+    env_hpacker_pythonbin = os.environ.get("HPACKER_PYTHONBIN")
+    if env_hpacker_pythonbin is not None:
+        logger.info(f"Using HPACKER_PYTHONBIN from environment: {env_hpacker_pythonbin}")
+        hpacker_pythonbin = env_hpacker_pythonbin
+    else:
+        ensure_hpacker_install(venv_dir=HPACKER_VENV_DIR, repo_dir=HPACKER_REPO_DIR)
+
+        hpacker_pythonbin = os.path.join(
+            HPACKER_VENV_DIR,
+            "bin",
+            "python",
+        )
 
     result = subprocess.run(
         [


### PR DESCRIPTION
Include *.sh in pyproject.toml package-data so setup_sidechain_relax.sh is bundled in pip installs. Update README to mention manual hpacker install as fallback if automatic setup fails.

Fixes #208