### PR TITLE
fix: handle annotated tags in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,14 +14,15 @@ jobs:
     environment: publish-to-pypi
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Make sure tags are fetched, so we can get a version.
+      # Use --force to handle cases where a tag already exists locally from checkout.
       - run: |
-          git fetch --prune --unshallow --tags
+          git fetch --prune --unshallow --tags --force
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
## Problem

The Publish to PyPI workflow fails at the `git fetch --prune --unshallow --tags` step with:

```
! [rejected] v1.3.1 -> v1.3.1 (would clobber existing tag)
```

**Root cause:** `v1.3.1` is an annotated tag (created via GitHub's release UI). The `actions/checkout` step fetches the commit and creates a lightweight local ref, but `git fetch --tags` sees the remote annotated tag object has a different SHA — so it refuses to overwrite.

Previous releases used lightweight tags, so there was never a mismatch.

## Fix

- Add `--force` to `git fetch --tags` so it can update local tag refs to match the remote. This is safe — it only affects the ephemeral runner's local clone.
- Bump `actions/checkout` v2 → v4 and `actions/setup-python` v2 → v5 to resolve Node.js 20 deprecation warnings.

## To release v1.3.1

After merging, delete the existing `v1.3.1` tag/release on GitHub and re-create it (or re-run the failed workflow).