### PR TITLE
sample.py: Set minimum batch size to 1

### DIFF
--- a/src/bioemu/sample.py
+++ b/src/bioemu/sample.py
@@ -176,7 +176,8 @@ def main(
         f"Sampling {num_samples} structures for sequence of length {len(sequence)} residues..."
     )
     # Adjust batch size by sequence length since longer sequence require quadratically more memory
-    batch_size = int(batch_size_100 * (100 / len(sequence)) ** 2)
+    # batch size should be at least 1.
+    batch_size = max(1, int(batch_size_100 * (100 / len(sequence)) ** 2))
 
     batch_size = min(batch_size, num_samples)
     logger.info(f"Using batch size {min(batch_size, num_samples)}")


### PR DESCRIPTION
When the sequence is too long and the batch_size_100 argument too small, batch_size is calculated as 0, which does not make sense.

Fixes issue #215